### PR TITLE
newRule improvements

### DIFF
--- a/scripts/newRule.js
+++ b/scripts/newRule.js
@@ -54,11 +54,13 @@ const testConfigTemplate =
     "rules": {
         "${ruleKebabName}": true
     }
-}`;
+}
+`;
 
 const testTemplate =
 `** TEST CODE AND MARKUP HERE **
-   ~~~~ [example error so this test fails until you change it]`;
+   ~~~~ [example error so this test fails until you change it]
+`;
 
 const projectDir = path.dirname(__dirname);
 

--- a/scripts/newRule.js
+++ b/scripts/newRule.js
@@ -64,18 +64,10 @@ const testTemplate =
 
 const projectDir = path.dirname(__dirname);
 
-const newRulePath = `./src/rules/${ruleCamelName}Rule.ts`;
-fs.access(newRulePath, fs.F_OK, (err) => {
-    if (!err) {
-        // File already exists.
-        process.exit(1);
-    }
+const rulePath = path.join(projectDir, `./src/rules/${ruleCamelName}Rule.ts`);
+fs.writeFileSync(rulePath, ruleTemplate, {flag: 'wx'});
 
-    const rulePath = path.join(projectDir, newRulePath);
-    fs.writeFileSync(rulePath, ruleTemplate);
-
-    const testDir = path.join(projectDir, `test/rules/${ruleKebabName}`);
-    fs.mkdirSync(testDir);
-    fs.writeFileSync(path.join(testDir, "tslint.json"), testConfigTemplate);
-    fs.writeFileSync(path.join(testDir, "test.tsx.lint"), testTemplate);
-});
+const testDir = path.join(projectDir, `test/rules/${ruleKebabName}`);
+fs.mkdirSync(testDir);
+fs.writeFileSync(path.join(testDir, "tslint.json"), testConfigTemplate, {flag: 'wx'});
+fs.writeFileSync(path.join(testDir, "test.tsx.lint"), testTemplate, {flag: 'wx'});

--- a/scripts/newRule.js
+++ b/scripts/newRule.js
@@ -46,7 +46,8 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class ${walkerClassName} extends Lint.RuleWalker {
     // ** RULE IMPLEMENTATION HERE **
-}`;
+}
+`;
 
 const testConfigTemplate =
 `{
@@ -61,10 +62,18 @@ const testTemplate =
 
 const projectDir = path.dirname(__dirname);
 
-const rulePath = path.join(projectDir, `./src/rules/${ruleCamelName}Rule.ts`);
-fs.writeFileSync(rulePath, ruleTemplate)
+const newRulePath = `./src/rules/${ruleCamelName}Rule.ts`;
+fs.access(newRulePath, fs.F_OK, (err) => {
+    if (!err) {
+        // File already exists.
+        process.exit(1);
+    }
 
-const testDir = path.join(projectDir, `test/rules/${ruleKebabName}`);
-fs.mkdir(testDir);
-fs.writeFileSync(path.join(testDir, "tslint.json"), testConfigTemplate);
-fs.writeFileSync(path.join(testDir, "test.tsx.lint"), testTemplate);
+    const rulePath = path.join(projectDir, newRulePath);
+    fs.writeFileSync(rulePath, ruleTemplate);
+
+    const testDir = path.join(projectDir, `test/rules/${ruleKebabName}`);
+    fs.mkdirSync(testDir);
+    fs.writeFileSync(path.join(testDir, "tslint.json"), testConfigTemplate);
+    fs.writeFileSync(path.join(testDir, "test.tsx.lint"), testTemplate);
+});


### PR DESCRIPTION
- If the `${ruleCamelName}Rule.ts` file exists, stop the new rule creation (so nothing is overwritten).
- Switch from `mkDir` to `mkDirSync` so the folder definitely exists by the time the test files are created.
- Add new line to end of rule file.