### PR TITLE
Add new rule jsx-boolean-value rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Sample configuration where `tslint.json` lives adjacent to your `node_modules` f
   ```
 - `jsx-ban-props` (since v2.3.0)
   - Allows blacklisting of props in JSX with an optional explanatory message in the reported failure.
+- `jsx-boolean-value`
+  - When using a boolean attribute in JSX, you can set the attribute value to true or omit the value. This rule will enforce one or the other to keep consistency in your code.
+  - Rule options: `always`, `never`
+  - Default is set to `never`
 - `jsx-curly-spacing` (since v1.1.0)
   - Requires _or_ bans spaces between curly brace characters in JSX.
   - Rule options: `["always", "never"]`
@@ -60,7 +64,7 @@ Sample configuration where `tslint.json` lives adjacent to your `node_modules` f
     Instead, [use a callback](https://facebook.github.io/react/docs/more-about-refs.html#the-ref-callback-attribute).
   - Rule options: _none_
 - `jsx-use-translation-function` (since v2.4.0)
-   - Enforces use of a translation function. Plain string literals are disallowed in JSX when enabled. 
+   - Enforces use of a translation function. Plain string literals are disallowed in JSX when enabled.
    - Rule options: _none_
    - Off by default
 - `jsx-self-close` (since v0.4.0)

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Sample configuration where `tslint.json` lives adjacent to your `node_modules` f
   - Allows blacklisting of props in JSX with an optional explanatory message in the reported failure.
 - `jsx-boolean-value`
   - When using a boolean attribute in JSX, you can set the attribute value to true or omit the value. This rule will enforce one or the other to keep consistency in your code.
-  - Rule options: `always`, `never`
-  - Default is set to `never`
+  - Rule options: `always`, `never`.
+  - Default is set to `never`.
 - `jsx-curly-spacing` (since v1.1.0)
   - Requires _or_ bans spaces between curly brace characters in JSX.
   - Rule options: `["always", "never"]`

--- a/src/rules/jsxBooleanValueRule.ts
+++ b/src/rules/jsxBooleanValueRule.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2017 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Lint from "tslint";
+import * as ts from "typescript";
+
+const OPTION_ALWAYS = "always";
+const OPTION_NEVER = "never";
+const BOOLEAN_RULE_VALUES = [OPTION_ALWAYS, OPTION_NEVER];
+const BOOLEAN_RULE_OBJECT = {
+    enum: BOOLEAN_RULE_VALUES,
+    type: "string",
+};
+
+export class Rule extends Lint.Rules.AbstractRule {
+    /* tslint:disable:object-literal-sort-keys */
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: "jsx-boolean-value",
+        description: "Enforce boolean attribute notation in jsx.",
+        optionsDescription: Lint.Utils.dedent`
+            One of the following two options must be provided:
+            * \`"${OPTION_ALWAYS}"\` requires JSX boolean values to always be set.
+            * \`"${OPTION_NEVER}"\` prevents JSX boolean values to be explicity set as \`true\``,
+        options: {
+            type: "array",
+            items: [BOOLEAN_RULE_OBJECT],
+            minLength: 1,
+            maxLength: 1,
+        },
+        optionExamples: [
+            `[true, "${OPTION_ALWAYS}"]`,
+            `[true, "${OPTION_NEVER}"]`,
+        ],
+        type: "style",
+        typescriptOnly: true,
+    };
+    /* tslint:enable:object-literal-sort-keys */
+
+    public static NEVER_MESSAGE = `Value must be omitted for boolean attributes`;
+    public static ALWAYS_MESSAGE = `Value must be set for boolean attributes`;
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new JsxBooleanValueWalker(sourceFile, this.getOptions()));
+    }
+}
+
+class JsxBooleanValueWalker extends Lint.RuleWalker {
+    protected visitJsxAttribute(node: ts.JsxAttribute) {
+
+        if (node.initializer && node.initializer.kind === ts.SyntaxKind.JsxExpression) {
+            const kind = node.initializer.expression && node.initializer.expression.kind;
+            const isValueTrue = kind === ts.SyntaxKind.TrueKeyword;
+            const noOptionsSet = !this.hasOption(OPTION_ALWAYS) && !this.hasOption(OPTION_NEVER);
+
+            if ((noOptionsSet || this.hasOption(OPTION_NEVER)) && isValueTrue) {
+                this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.NEVER_MESSAGE));
+            }
+        }
+
+        if (!node.initializer && (this.hasOption(OPTION_ALWAYS))) {
+            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.ALWAYS_MESSAGE));
+        }
+    }
+}

--- a/test/rules/jsx-boolean-value/always/test.tsx.lint
+++ b/test/rules/jsx-boolean-value/always/test.tsx.lint
@@ -1,0 +1,7 @@
+function render(){
+  return(
+    <Foo readOnly={true} />
+    <Foo readOnly />
+         ~~~~~~~~ [Value must be set for boolean attributes]
+  );
+}

--- a/test/rules/jsx-boolean-value/always/tslint.json
+++ b/test/rules/jsx-boolean-value/always/tslint.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "jsx-boolean-value": [true, "always"]
+    }
+}

--- a/test/rules/jsx-boolean-value/false/test.tsx.lint
+++ b/test/rules/jsx-boolean-value/false/test.tsx.lint
@@ -1,0 +1,7 @@
+function render(){
+  return(
+    <Foo readOnly />
+    <Foo readOnly={true} />
+    <Foo readOnly={false} />
+  );
+}

--- a/test/rules/jsx-boolean-value/false/tslint.json
+++ b/test/rules/jsx-boolean-value/false/tslint.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "jsx-boolean-value": [false]
+    }
+}

--- a/test/rules/jsx-boolean-value/never/test.tsx.lint
+++ b/test/rules/jsx-boolean-value/never/test.tsx.lint
@@ -1,0 +1,7 @@
+function render(){
+  return(
+    <Foo readOnly={true} />
+         ~~~~~~~~~~~~~~~ [Value must be omitted for boolean attributes]
+    <Foo readOnly />
+  );
+}

--- a/test/rules/jsx-boolean-value/never/tslint.json
+++ b/test/rules/jsx-boolean-value/never/tslint.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "jsx-boolean-value": [true, "never"]
+    }
+}

--- a/test/rules/jsx-boolean-value/true/test.tsx.lint
+++ b/test/rules/jsx-boolean-value/true/test.tsx.lint
@@ -1,0 +1,8 @@
+function render(){
+  return(
+    <Foo readOnly={true} />
+         ~~~~~~~~~~~~~~~ [Value must be omitted for boolean attributes]
+    <Foo readOnly />
+    <Foo readOnly={false} />
+  );
+}

--- a/test/rules/jsx-boolean-value/true/tslint.json
+++ b/test/rules/jsx-boolean-value/true/tslint.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "jsx-boolean-value": [true]
+    }
+}


### PR DESCRIPTION
Created a `tslint-react` equivalent rule for `eslint-plugin-react`'s [`jsx-boolean-value`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md) rule.

