### PR TITLE
jsx-no-lambda checks if lambda is passed directly to attribute (fixes #29)

### DIFF
--- a/src/rules/jsxNoLambdaRule.ts
+++ b/src/rules/jsxNoLambdaRule.ts
@@ -29,22 +29,22 @@ export class Rule extends Lint.Rules.AbstractRule {
 function walk(ctx: Lint.WalkContext<void>) {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
         // continue iterations until JsxAttribute will be found
-        if (node.kind !== ts.SyntaxKind.JsxAttribute) {
-            return ts.forEachChild(node, cb);
+        if (node.kind === ts.SyntaxKind.JsxAttribute) {
+            const initializer = (node as ts.JsxAttribute).initializer;
+
+            // early exit in case when initializer is string literal or not provided (e.d. `disabled`)
+            if (!initializer || initializer.kind !== ts.SyntaxKind.JsxExpression) {
+                return;
+            }
+
+            const expression = (initializer as ts.JsxExpression).expression;
+
+            if (expression && isLambda(expression)) {
+                return ctx.addFailureAtNode(expression, Rule.FAILURE_STRING);
+            }
         }
 
-        const initializer = (node as ts.JsxAttribute).initializer;
-
-        // early exit in case when initializer is string literal or not provided (e.d. `disabled`)
-        if (!initializer || initializer.kind !== ts.SyntaxKind.JsxExpression) {
-            return;
-        }
-
-        const expression = (initializer as ts.JsxExpression).expression;
-
-        if (expression && isLambda(expression)) {
-            return ctx.addFailureAtNode(expression, Rule.FAILURE_STRING);
-        }
+        return ts.forEachChild(node, cb);
     });
 }
 

--- a/src/rules/jsxNoLambdaRule.ts
+++ b/src/rules/jsxNoLambdaRule.ts
@@ -22,39 +22,42 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "Lambdas are forbidden in JSX attributes due to their rendering performance impact";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        const jsxNoLambdaWalker = new JsxNoLambdaWalker(sourceFile, this.getOptions());
-        return this.applyWithWalker(jsxNoLambdaWalker);
+        return this.applyWithFunction(sourceFile, walk);
     }
 }
 
-class JsxNoLambdaWalker extends Lint.RuleWalker {
-    private isInJsxAttribute = false;
-
-    protected visitNode(node: ts.Node) {
-        if (node.kind === ts.SyntaxKind.JsxAttribute) {
-            this.isInJsxAttribute = true;
-            super.visitNode(node);
-            this.isInJsxAttribute = false;
-        } else {
-            super.visitNode(node);
+function walk(ctx: Lint.WalkContext<void>) {
+    return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
+        // continue iterations until JsxAttribute will be found
+        if (node.kind !== ts.SyntaxKind.JsxAttribute) {
+            return ts.forEachChild(node, cb);
         }
-    }
 
-    protected visitFunctionExpression(node: ts.FunctionExpression) {
-        if (this.isInJsxAttribute) {
-            this.reportFailure(node);
+        const initializer = (node as ts.JsxAttribute).initializer;
+
+        // early exit in case when initializer is string literal or not provided (e.d. `disabled`)
+        if (!initializer || initializer.kind !== ts.SyntaxKind.JsxExpression) {
+            return;
         }
-        super.visitFunctionExpression(node);
-    }
 
-    protected visitArrowFunction(node: ts.ArrowFunction) {
-        if (this.isInJsxAttribute) {
-            this.reportFailure(node);
+        const expression = (initializer as ts.JsxExpression).expression;
+
+        if (expression && isLambda(expression)) {
+            return ctx.addFailureAtNode(expression, Rule.FAILURE_STRING);
         }
-        super.visitArrowFunction(node);
-    }
+    });
+}
 
-    private reportFailure(node: ts.Node) {
-        this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+function isLambda(node: ts.Node): boolean {
+    switch (node.kind) {
+        case ts.SyntaxKind.FunctionExpression:
+        case ts.SyntaxKind.ArrowFunction:
+            return true;
+
+        case ts.SyntaxKind.ParenthesizedExpression:
+            return isLambda((node as ts.ParenthesizedExpression).expression);
+
+        default:
+            return false;
     }
 }

--- a/test/rules/jsx-no-lambda/test.tsx.lint
+++ b/test/rules/jsx-no-lambda/test.tsx.lint
@@ -59,4 +59,25 @@ const ComponentWithFunctionCallback: React.SFC<{}> = () => (
     })} />
 );
 
+const ComplexComposableComponentWith: React.SFC<{}> = () => (
+    <ComposableComponent
+        header={<HeadingComponent title="test" onClick={()=>{console.log('arrow function show be reported')}} />}
+                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~      [0]
+        footer={(
+            <FooterComponent
+                disabled
+                onClick={function(ev) {
+                         ~~~~~~~~~~~~~~
+                    console.log('function should be reported', ev);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                }}
+~~~~~~~~~~~~~~~~~  [0]
+            />
+        )}
+    >
+        {bodyElements.map(x => x.toValidLambda())}
+        {/*<a href="#" onClick={()=>{console.log('in comment)}}>Legacy code</a>*/}
+    </ComposableComponent>
+);
+
 [0]: Lambdas are forbidden in JSX attributes due to their rendering performance impact

--- a/test/rules/jsx-no-lambda/test.tsx.lint
+++ b/test/rules/jsx-no-lambda/test.tsx.lint
@@ -10,7 +10,7 @@ const myButton2 = (
                      ~~~~~~~~~~~~~
         // another bad one
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
-    }} />
+    }} disabled/>
 ~~~~~     [0]
 )
 
@@ -48,5 +48,15 @@ const StatelessComponent: React.SFC<{}> = () => {
         </div>
     );
 };
+
+const ComponentWithArrowCallback: React.SFC<{}> = () => (
+    <Currency amount={ _.sumBy(items, (item: Item) => item.value) } />
+);
+
+const ComponentWithFunctionCallback: React.SFC<{}> = () => (
+    <Currency amount={ _.sumBy(items, function(item: Item) {
+        return item.value;
+    })} />
+);
 
 [0]: Lambdas are forbidden in JSX attributes due to their rendering performance impact


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #29
- [x] ~New feature,~ bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

This PR contain rewrite for `jsx-no-lambda` that will report error only if arrow function or function expression are provided directly as attribute expression. 

#### Is there anything you'd like reviewers to focus on?
This PR replaces AST Walker with function.

Please suggest other edge cases that should be also reported.

<!-- optional -->

#### CHANGELOG.md entry:
[bugfix] `jsx-no-lambda` checks if lambda is passed directly to attribute