### PR TITLE
Update jsx-alignment for TS 2.3

### DIFF
--- a/src/rules/jsxAlignmentRule.ts
+++ b/src/rules/jsxAlignmentRule.ts
@@ -56,10 +56,11 @@ class JsxAlignmentWalker extends Lint.RuleWalker {
 
     private checkElement(
         elementOpen: ts.LineAndCharacter,
-        attributes: Array<ts.JsxAttribute | ts.JsxSpreadAttribute>,
+        attributes: Array<ts.JsxAttribute | ts.JsxSpreadAttribute> | { properties: Array<ts.JsxAttribute | ts.JsxSpreadAttribute> },
         elementClose: ts.LineAndCharacter,
         closingTag?: ts.JsxClosingElement,
     ) {
+        attributes = attributes == null || Array.isArray(attributes) ? attributes : attributes.properties;
         if (attributes == null || attributes.length === 0) { return; }
 
         // in a line like "const element = <Foo",


### PR DESCRIPTION
In TS 2.3, the `attributes` is a separate node type instead of an array.

To support it without requiring a version bump, make the attributes argument an union type, and grab the `properties` property if the argument is not an array.

c.f. https://github.com/Microsoft/TypeScript/blob/2e43c869b/lib/typescript.d.ts#L1019-L1020

Fixes #87