### PR TITLE
jsx-no-lambda: allow lambdas on ref attribute

### DIFF
--- a/src/rules/jsxNoLambdaRule.ts
+++ b/src/rules/jsxNoLambdaRule.ts
@@ -54,6 +54,12 @@ function walk(ctx: Lint.WalkContext<void>) {
                 return;
             }
 
+            // Ignore "ref" attribute.
+            // ref is not part of the props so using lambdas here will not trigger useless re-renders
+            if (node.name.text === "ref") {
+                return;
+            }
+
             const { expression } = initializer;
             if (expression !== undefined && isLambda(expression)) {
                 return ctx.addFailureAtNode(expression, Rule.FAILURE_STRING);

--- a/test/rules/jsx-no-lambda/test.tsx.lint
+++ b/test/rules/jsx-no-lambda/test.tsx.lint
@@ -35,8 +35,8 @@ const anotherOkFunction = () {
 class TypicalRefHandler extends React.Component<{}, {}> {
     private element: HTMLElement;
     public render() {
+        // ref is not part of the props so using lambdas here will not trigger useless re-renders
         return <div ref={(ref) => this.element = ref} />
-                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~     [0]
     }
 }
 


### PR DESCRIPTION
Fixes issue https://github.com/palantir/tslint-react/issues/26

The main performance drop with arrow function as prop is due to pure components re-rendering when it could be avoided. The creation of a new function is not a real problem.

The `ref` attribute is not part of the props so it's ok to use an arrow function here.

See: https://github.com/facebook/react/issues/9086#issuecomment-283348191

Rather than adding a configuration, I simply ignore "ref" attribute. I think that this is what makes the more sense in most situations.