### PR TITLE
Add whitelist to jsx-no-lambda

### DIFF
--- a/test/rules/jsx-no-lambda/test.tsx.lint
+++ b/test/rules/jsx-no-lambda/test.tsx.lint
@@ -35,7 +35,7 @@ const anotherOkFunction = () {
 class TypicalRefHandler extends React.Component<{}, {}> {
     private element: HTMLElement;
     public render() {
-        // ref is not part of the props so using lambdas here will not trigger useless re-renders
+        // ref is whitelisted in the config
         return <div ref={(ref) => this.element = ref} />
     }
 }
@@ -79,5 +79,7 @@ const ComplexComposableComponentWith: React.SFC<{}> = () => (
         {/*<a href="#" onClick={()=>{console.log('in comment)}}>Legacy code</a>*/}
     </ComposableComponent>
 );
+
+<Component whiteListedProp={() => {}} />
 
 [0]: Lambdas are forbidden in JSX attributes due to their rendering performance impact

--- a/test/rules/jsx-no-lambda/tslint.json
+++ b/test/rules/jsx-no-lambda/tslint.json
@@ -1,5 +1,5 @@
 {
     "rules": {
-        "jsx-no-lambda": true
+        "jsx-no-lambda": [true, "ref", "whiteListedProp"]
     }
 }


### PR DESCRIPTION
To address remaining conversation in #26.

This can be considered a breaking change since users that do not change their config will see new linting errors for anonymous functions in `ref` props. One way to resolve this is to put `ref` in the whitelist by default if no whitelist options are provided.