### PR TITLE
Fixes for translation lint where punctuation and HTML entities are side by side

### DIFF
--- a/test/rules/jsx-use-translation-function/allow-both/test.tsx.lint
+++ b/test/rules/jsx-use-translation-function/allow-both/test.tsx.lint
@@ -42,20 +42,19 @@
 <div> & </div>
 
 <div>:&nbsp;</div>
-     ~~~~~~~       [0]
+
+<div>:&nbsp</div>
+     ~~~~~~       [0]
 
 <div>{' - '}</div>
 
 <input placeholder="-" />
 
 <div>&nbsp;</div>
-     ~~~~~~         [0]
 
 <div>{'&nbsp;'}</div>
-     ~~~~~~~~~~       [0]
 
 <input placeholder="&nbsp;" />
-                   ~~~~~~~~ [1]
 
 <div>hello - world</div>
      ~~~~~~~~~~~~~       [0]

--- a/test/rules/jsx-use-translation-function/allow-both/tslint.json
+++ b/test/rules/jsx-use-translation-function/allow-both/tslint.json
@@ -1,0 +1,7 @@
+{
+    "rules": {
+        "jsx-use-translation-function": {
+            "options": ["allow-punctuation", "allow-htmlentities"]
+        }
+    }
+}

--- a/test/rules/jsx-use-translation-function/allow-htmlentities/test.tsx.lint
+++ b/test/rules/jsx-use-translation-function/allow-htmlentities/test.tsx.lint
@@ -48,9 +48,17 @@
 
 <div>&nbsp;</div>
 
+<div>&nbsp;&nbsp;</div>
+
 <div>{'&nbsp;'}</div>
 
 <input placeholder="&nbsp;" />
+
+<div>hello - world</div>
+     ~~~~~~~~~~~~~       [0]
+
+<div>hello&nbsp;world</div>
+     ~~~~~~~~~~~~~~~~       [0]
 
 [0]: String literals are disallowed as JSX. Use a translation function
 [1]: String literal is not allowed for value of placeholder. Use a translation function


### PR DESCRIPTION
This case came up running lint across our larger code base, where strings like `{var1}:&nbsp;{var2}` were incorrectly flagged when both punctuation and HTML entities were allowed.