### PR TITLE
Allow js files to be linted by jsx-ban-elements and jsx-curly-spacing rules

### DIFF
--- a/src/rules/jsxBanElementsRule.ts
+++ b/src/rules/jsxBanElementsRule.ts
@@ -43,7 +43,7 @@ export class Rule extends Lint.Rules.AbstractRule {
             types that match \`regex\``,
         optionExamples: [[true, ["Object", "Use {} instead."], ["String"]]],
         type: "typescript",
-        typescriptOnly: true,
+        typescriptOnly: false,
     };
     /* tslint:enable:object-literal-sort-keys */
 

--- a/src/rules/jsxCurlySpacingRule.ts
+++ b/src/rules/jsxCurlySpacingRule.ts
@@ -49,7 +49,7 @@ export class Rule extends Lint.Rules.AbstractRule {
             `[true, "${OPTION_NEVER}"]`,
         ],
         type: "style",
-        typescriptOnly: true,
+        typescriptOnly: false,
     };
     /* tslint:enable:object-literal-sort-keys */
 


### PR DESCRIPTION
Fixes #157 