### PR TITLE
Fix issue #140

### DIFF
--- a/src/rules/jsxCurlySpacingRule.ts
+++ b/src/rules/jsxCurlySpacingRule.ts
@@ -124,15 +124,10 @@ function walk(ctx: Lint.WalkContext<string | undefined>): void {
 }
 
 function getTokensCombinedText(firstToken: ts.Node, nextToken: ts.Node) {
-    const parentNodeText = nextToken.parent!.getText();
-    const firstTokenText = firstToken.getText();
-    const secondTokenText = nextToken.getText();
-    const secondTokenTextLocation = parentNodeText.indexOf(secondTokenText);
-    const firstTokenTextLocation = parentNodeText.indexOf(firstTokenText);
-    const combinedTokeText = parentNodeText.slice(
-        firstTokenTextLocation,
-        secondTokenTextLocation + secondTokenText.length,
-    );
+    const parent = nextToken.parent!;
+    const combinedTokeText = parent.getText().slice(
+        firstToken.getStart() - parent.getStart(),
+        nextToken.getStart() + nextToken.getWidth() - parent.getStart());
 
     return combinedTokeText;
 }

--- a/src/rules/jsxCurlySpacingRule.ts
+++ b/src/rules/jsxCurlySpacingRule.ts
@@ -127,7 +127,8 @@ function getTokensCombinedText(firstToken: ts.Node, nextToken: ts.Node) {
     const parent = nextToken.parent!;
     const combinedTokeText = parent.getText().slice(
         firstToken.getStart() - parent.getStart(),
-        nextToken.getStart() + nextToken.getWidth() - parent.getStart());
+        nextToken.getStart() + nextToken.getWidth() - parent.getStart(),
+    );
 
     return combinedTokeText;
 }

--- a/test/rules/jsx-curly-spacing/never/test.tsx.fix
+++ b/test/rules/jsx-curly-spacing/never/test.tsx.fix
@@ -57,3 +57,10 @@ const failH = <App foo={{ bar:baz }} {...baz}>
 
 const passI = <App foo={/* comment */
                    /* comment 2 */ should_not_matter_because_multiline}/>
+
+const passJ = <App foo={({ bar }) =>
+                  bar ? (
+                    <div></div>
+                  ) : null
+                }
+              />

--- a/test/rules/jsx-curly-spacing/never/test.tsx.lint
+++ b/test/rules/jsx-curly-spacing/never/test.tsx.lint
@@ -89,3 +89,10 @@ const failH = <App foo={{ bar:baz }} {...baz}>
 
 const passI = <App foo={/* comment */
                    /* comment 2 */ should_not_matter_because_multiline}/>
+
+const passJ = <App foo={({ bar }) =>
+                  bar ? (
+                    <div></div>
+                  ) : null
+                }
+              />


### PR DESCRIPTION
The problem was caused by `getTokensCombinedText` returning an incorrect
slice which caused the multiline check to fail.