### PR TITLE
Rule prohibiting use of object and array literals in props

### DIFF
--- a/src/rules/jsxNoLiteralRule.ts
+++ b/src/rules/jsxNoLiteralRule.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2016 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Lint from "tslint";
+import { isJsxAttribute, isJsxExpression } from "tsutils";
+import * as ts from "typescript";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    /* tslint:disable:object-literal-sort-keys */
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: "jsx-no-literal",
+        description: "Checks for fresh object and array literals used in JSX attributes",
+        descriptionDetails: Lint.Utils.dedent
+            `Creating new object and array literals inside the render call stack works against pure component \
+            rendering. When doing an equality check between two new object literals, React will always \
+            consider them unequal values and force the component to re-render more often than necessary.`,
+        options: null,
+        optionsDescription: "",
+        optionExamples: ["true"],
+        type: "functionality",
+        typescriptOnly: false,
+    };
+    /* tslint:enable:object-literal-sort-keys */
+
+    public static FAILURE_STRING = "Object and array literals are forbidden in JSX attributes" +
+        " due to their rendering performance impact";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithFunction(sourceFile, walk);
+    }
+}
+
+function walk(ctx: Lint.WalkContext<void>) {
+    return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
+        // continue iterations until JsxAttribute will be found
+        if (isJsxAttribute(node)) {
+            const { initializer } = node;
+            // early exit in case when initializer is string literal or not provided (e.d. `disabled`)
+            if (initializer === undefined || !isJsxExpression(initializer)) {
+                return;
+            }
+
+            // Ignore "ref" attribute.
+            // ref is not part of the props.
+            if (node.name.text === "ref") {
+                return;
+            }
+
+            const { expression } = initializer;
+            if (expression !== undefined && isLiteral(expression)) {
+                return ctx.addFailureAtNode(expression, Rule.FAILURE_STRING);
+            }
+        }
+
+        return ts.forEachChild(node, cb);
+    });
+}
+
+function isLiteral(node: ts.Node): boolean {
+    switch (node.kind) {
+        case ts.SyntaxKind.ArrayLiteralExpression:
+        case ts.SyntaxKind.ObjectLiteralExpression:
+            return true;
+
+        case ts.SyntaxKind.ParenthesizedExpression:
+            return isLiteral((node as ts.ParenthesizedExpression).expression);
+
+        default:
+            return false;
+    }
+}

--- a/test/rules/jsx-no-literal/test.tsx.lint
+++ b/test/rules/jsx-no-literal/test.tsx.lint
@@ -1,0 +1,27 @@
+export const myButton = (
+    <button style={{background: "red"}}>
+                   ~~~~~~~~~~~~~~~~~~~    [0]
+        Log something
+    </button>
+);
+
+const myButton2 = (
+    <Toolbar icons={[<Icon type="save" />, <Icon type="load" />]} disabled>This is bad</Button>
+                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    [0]
+)
+
+const anchorStyle = {color: "blue"}; // this one is kosher
+export const myAnchorButton = (
+    <a href="#" style={anchorStyle}>
+        Click me
+    </a>
+);
+
+export const Languages = () => {
+    return <ul>{
+        /* literal outisde of props is ok */
+        ["En", "Ru", "Fr", "Jp"].map(lang => <li key={lang}>{lang}</li>)
+    }</ul>;
+}
+
+[0]: Object and array literals are forbidden in JSX attributes due to their rendering performance impact

--- a/test/rules/jsx-no-literal/tslint.json
+++ b/test/rules/jsx-no-literal/tslint.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "jsx-no-literal": true
+    }
+}


### PR DESCRIPTION
By analogy to `jsx-no-lambda` and for same reasons. Closes #89.