### PR TITLE
Allow jsx-no-bind and jsx-no-lambda to ignore DOMComponents

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,6 +46,10 @@ export function getDeleteFixForSpaceBetweenTokens(
     }
 }
 
+export function isDOMComponent(node: ts.JsxOpeningElement | ts.JsxSelfClosingElement): boolean {
+    return /^[a-z]/.test(node.tagName.getText());
+}
+
 function getTotalCharCount(comments: ts.CommentRange[]) {
     return comments
         .map((comment) => comment.end - comment.pos)

--- a/test/rules/jsx-no-bind/test.tsx.lint
+++ b/test/rules/jsx-no-bind/test.tsx.lint
@@ -1,18 +1,28 @@
 function foo() {
 }
 
-export const myButton = (
+export const domButton = (
     <button onClick={foo.bind(this)}>
-                     ~~~~~~~~~~~~~~   [0]
         Log something
     </button>
 );
 
+export const domButton2 = (
+    <button onClick={foo.bind(this)} />
+);
+
+export const myButton = (
+    <Button onClick={foo.bind(this)}>
+                     ~~~~~~~~~~~~~~   [0]
+        Log something
+    </Button>
+);
+
 export const myButton2 = (
-    <button onClick={this.foo.bind(this)}>
+    <Button onClick={this.foo.bind(this)}>
                      ~~~~~~~~~~~~~~~~~~~   [0]
         Log something
-    </button>
+    </Button>
 );
 
 export const selector = (

--- a/test/rules/jsx-no-bind/tslint.json
+++ b/test/rules/jsx-no-bind/tslint.json
@@ -1,5 +1,5 @@
 {
     "rules": {
-        "jsx-no-bind": true
+        "jsx-no-bind": [true, "allow-dom-component"]
     }
 }

--- a/test/rules/jsx-no-lambda/test.tsx.lint
+++ b/test/rules/jsx-no-lambda/test.tsx.lint
@@ -1,12 +1,12 @@
 export const myButton = (
-    <button onClick={() => console.log("clicked")}>
+    <Button onClick={() => console.log("clicked")}>
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~   [0]
         Log something
-    </button>
+    </Button>
 );
 
 const myButton2 = (
-    <button onClick={function () {
+    <Button onClick={function () {
                      ~~~~~~~~~~~~~
         // another bad one
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -14,14 +14,26 @@ const myButton2 = (
 ~~~~~     [0]
 )
 
+export const myDOMButton = (
+    <button onClick={() => console.log("clicked")}>
+        Log something
+    </button>
+);
+
+const myDOMButton2 = (
+    <button onClick={function () {
+        // another bad one
+    }} disabled/>
+)
+
 const handleClick = () => {
     // this one is kosher
 };
 
 export const myAnchorButton = (
-    <a href="#" onClick={handleClick}>
+    <Link href="#" onClick={handleClick}>
         Go nowhere, just log something
-    </a>
+    </Link>
 );
 
 function randomOkFunction() {

--- a/test/rules/jsx-no-lambda/tslint.json
+++ b/test/rules/jsx-no-lambda/tslint.json
@@ -1,5 +1,5 @@
 {
     "rules": {
-        "jsx-no-lambda": true
+        "jsx-no-lambda": [true, "allow-dom-component"]
     }
 }


### PR DESCRIPTION
I think function binding and anonymous functions with DOMComponent would be fine, the cost to create a function each time is not significant.
So it makes sense to add a option to ignore DOMComponents.

`eslint-plugin-react` has added this option as https://github.com/yannickcr/eslint-plugin-react/issues/1238
