### PR TITLE
Fix jsx-key can't detect error in parenthesized expression

### DIFF
--- a/src/rules/jsxKeyRule.ts
+++ b/src/rules/jsxKeyRule.ts
@@ -72,6 +72,8 @@ function walk(ctx: Lint.WalkContext<void>): void {
             if (mapFn !== undefined && (isArrowFunction(mapFn) || isFunctionExpression(mapFn))) {
                 if (isJsxElement(mapFn.body) || isJsxSelfClosingElement(mapFn.body)) {
                     checkIteratorElement(mapFn.body, ctx);
+                } else if (isParenthesizedExpression(mapFn.body) && isJsxSelfClosingElement(mapFn.body.expression)) {
+                    checkIteratorElement(mapFn.body.expression, ctx);
                 } else if (isBlock(mapFn.body)) {
                     const returnStatement = getReturnStatement(mapFn.body.statements);
 

--- a/src/rules/jsxKeyRule.ts
+++ b/src/rules/jsxKeyRule.ts
@@ -72,7 +72,10 @@ function walk(ctx: Lint.WalkContext<void>): void {
             if (mapFn !== undefined && (isArrowFunction(mapFn) || isFunctionExpression(mapFn))) {
                 if (isJsxElement(mapFn.body) || isJsxSelfClosingElement(mapFn.body)) {
                     checkIteratorElement(mapFn.body, ctx);
-                } else if (isParenthesizedExpression(mapFn.body) && isJsxSelfClosingElement(mapFn.body.expression)) {
+                } else if (
+                    isParenthesizedExpression(mapFn.body) &&
+                    (isJsxElement(mapFn.body.expression) || isJsxSelfClosingElement(mapFn.body.expression))
+                ) {
                     checkIteratorElement(mapFn.body.expression, ctx);
                 } else if (isBlock(mapFn.body)) {
                     const returnStatement = getReturnStatement(mapFn.body.statements);

--- a/test/rules/jsx-key/test.tsx.lint
+++ b/test/rules/jsx-key/test.tsx.lint
@@ -5,6 +5,7 @@ fn()
 [1, 2, 3].map(function(x) { return <App key={x} /> });
 [1, 2, 3].map(x => <App key={x} />);
 [1, 2, 3].map(x => (<App key={x} />));
+[1, 2, 3].map(x => (<App key={x}>app</App>));
 [1, 2, 3].map(x => { return <App key={x} /> });
 [1, 2, 3].map(x => { return (<App key={x} />) });
 [1, 2, 3].foo(x => <App />);
@@ -32,6 +33,9 @@ foo(() => <div />)
 
 [3, 4, 5].map(x => (<App />));
                     ~~~~~~~     [0]
+
+[3, 4, 5].map(x => (<App>app</App>));
+                    ~~~~~~~~~~~~~~     [0]
                    
 [6, 7, 8].map(x => { return <App /> });
                             ~~~~~~~      [0]

--- a/test/rules/jsx-key/test.tsx.lint
+++ b/test/rules/jsx-key/test.tsx.lint
@@ -4,7 +4,9 @@ fn()
 [<App key={0} />, <App key={1} />];
 [1, 2, 3].map(function(x) { return <App key={x} /> });
 [1, 2, 3].map(x => <App key={x} />);
+[1, 2, 3].map(x => (<App key={x} />));
 [1, 2, 3].map(x => { return <App key={x} /> });
+[1, 2, 3].map(x => { return (<App key={x} />) });
 [1, 2, 3].foo(x => <App />);
 var App = () => <div />;
 [1, 2, 3].map(function(x) { return; });
@@ -22,8 +24,14 @@ foo(() => <div />)
 [1, 2, 3].map(function(x) { return <App /> });
                                    ~~~~~~~      [0]
 
+[1, 2, 3].map(function(x) { return (<App />) });
+                                    ~~~~~~~       [0]
+
 [3, 4, 5].map(x => <App />);
                    ~~~~~~~    [0]
+
+[3, 4, 5].map(x => (<App />));
+                    ~~~~~~~     [0]
                    
 [6, 7, 8].map(x => { return <App /> });
                             ~~~~~~~      [0]


### PR DESCRIPTION
Fix #187

The current implementation miss the case where an arrow function returns `()`; i.e.
```js
[3, 4, 5].map(x => (<App />));
[3, 4, 5].map(x => (<App>app</App>));
```

It should be the following code instead.
```js
[3, 4, 5].map(x => (<App key={x} />));
[3, 4, 5].map(x => (<App key={x}>app</App>));
```