### PR TITLE
Add auto fixer for jsx-space-before-trailing-slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The built-in configuration preset you get with `"extends": "tslint-react"` is se
 - `jsx-space-before-trailing-slash`
   - Checks that self-closing JSX elements have a space before the '/>' part.
   - Rule options: _none_
+  - _Includes automatic code fix_
 - `jsx-wrap-multiline` (since v2.1)
   - Enforces that multiline JSX expressions are wrapped with parentheses.
   - Opening parenthesis must be followed by a newline.

--- a/src/rules/jsxSpaceBeforeTrailingSlashRule.ts
+++ b/src/rules/jsxSpaceBeforeTrailingSlashRule.ts
@@ -48,7 +48,8 @@ function walk(ctx: Lint.WalkContext<void>): void {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
         if (isJsxSelfClosingElement(node)) {
             if (!hasWhitespaceBeforeClosing(node.getText(ctx.sourceFile))) {
-                ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
+                const fix = Lint.Replacement.appendText(node.getEnd() - closingLength, " ");
+                ctx.addFailureAtNode(node, Rule.FAILURE_STRING, fix);
             }
         }
         return ts.forEachChild(node, cb);

--- a/test/rules/jsx-space-before-trailing-slash/test.tsx.fix
+++ b/test/rules/jsx-space-before-trailing-slash/test.tsx.fix
@@ -1,0 +1,15 @@
+<div>
+    Contents
+</div>
+
+<span />
+
+<button />
+
+<h2 class="colouring" contents="B" />
+
+<button onClick="run()" />
+
+<img
+    src="./foo/bar.png"
+/>


### PR DESCRIPTION
Hi,

This PR adds an auto fixer for the jsxSpaceBeforeTrailingSlash rule, along with a test and readme update.

The auto-fix uses `appendText` to add a single space before offending closing tags.

Let me know if it's missing anything! Shoutout to @zapo for co-driving to do this! 🙌 