### PR TITLE
Add new rule noAccessStateInSetstate

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The built-in configuration preset you get with `"extends": "tslint-react"` is se
       size={size}
   />
   ```
+  - Rule options: _none_
 - `jsx-ban-elements` (since v3.4.0)
   - Allows blacklisting of JSX elements with an optional explanatory message in the reported failure.
 - `jsx-ban-props` (since v2.3.0)
@@ -119,6 +120,22 @@ The built-in configuration preset you get with `"extends": "tslint-react"` is se
       </button>
   );
   ```
+  - Rule options: _none_
+- `no-access-state-in-setstate`
+  - Forbids accessing component state with `this.state` within `this.setState`
+  calls, since React might batch multiple `this.setState` calls, thus resulting
+  in accessing old state. Enforces use of callback argument instead.
+    ```ts
+  // bad
+  this.setState({
+      counter: this.state.counter + 1
+  });
+  // good
+  this.setState(
+      prevState => ({ counter: prevState.counter + 1 })
+  );
+  ```
+  - Rule options: _none_
 
 ### Development
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The built-in configuration preset you get with `"extends": "tslint-react"` is se
   - Forbids accessing component state with `this.state` within `this.setState`
   calls, since React might batch multiple `this.setState` calls, thus resulting
   in accessing old state. Enforces use of callback argument instead.
-    ```ts
+  ```ts
   // bad
   this.setState({
       counter: this.state.counter + 1

--- a/src/rules/noAccessStateInSetstateRule.ts
+++ b/src/rules/noAccessStateInSetstateRule.ts
@@ -24,9 +24,11 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-access-state-in-setstate",
         description: "Reports usage of this.state within setState",
-        rationale: Lint.Utils.dedent
-            `Usage of this.state might result in errors when two state calls are \
-            called in batch and thus referencing old state and not the current state.`,
+        rationale: Lint.Utils.dedent`
+            Usage of this.state might result in errors when two state calls are
+            called in batch and thus referencing old state and not the current state.
+            See [setState()](https://reactjs.org/docs/react-component.html#setstate) in the React API reference.
+        `,
         options: null,
         optionsDescription: "",
         type: "functionality",

--- a/src/rules/noAccessStateInSetstateRule.ts
+++ b/src/rules/noAccessStateInSetstateRule.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2018 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Lint from "tslint";
+import { isCallExpression } from "tsutils";
+import * as ts from "typescript";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    /* tslint:disable:object-literal-sort-keys */
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: "no-access-state-in-setstate",
+        description: "Reports usage of this.state within setState",
+        rationale: Lint.Utils.dedent
+            `Usage of this.state might result in errors when two state calls are \
+            called in batch and thus referencing old state and not the current state.`,
+        options: null,
+        optionsDescription: "",
+        type: "functionality",
+        typescriptOnly: false,
+    };
+    /* tslint:enable:object-literal-sort-keys */
+
+    public static FAILURE_STRING = "Use callback in setState when referencing the previous state.";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithFunction(sourceFile, walk);
+    }
+}
+
+function walk(ctx: Lint.WalkContext<void>): void {
+    return ts.forEachChild(ctx.sourceFile, cb);
+
+    function cb(node: ts.Node): void {
+        if (!isCallExpression(node)) {
+            return ts.forEachChild(node, cb);
+        }
+        if (isStateUsedInSetStateWith(node)) {
+            ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
+        }
+        return;
+    }
+}
+
+function isStateUsedInSetStateWith(callExpression: ts.CallExpression): boolean {
+    if (callExpression.expression.getText() !== "this.setState") {
+        return false;
+    }
+    if (callExpression.arguments.length === 0) {
+        return false;
+    }
+
+    const firstCallExpressionArgument = callExpression.arguments[0];
+    const argumentAsText = firstCallExpressionArgument.getText();
+    return argumentAsText.indexOf("this.state.") !== -1;
+}

--- a/test/rules/no-access-state-in-setstate/test.tsx.lint
+++ b/test/rules/no-access-state-in-setstate/test.tsx.lint
@@ -28,41 +28,29 @@ class SomeReactComponent extends React.Component {
         }));
 
         this.setState({
-        ~~~~~~~~~~~~~~~
             foo: !this.state.foo
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                  ~~~~~~~~~~~~~~ [0]
         });
-~~~~~~~~~~ [0]
 
         this.setState({
-        ~~~~~~~~~~~~~~~
             foo: this.fooBar(this.state.foo)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                             ~~~~~~~~~~~~~~ [0]
         });
-~~~~~~~~~~ [0]
 
         this.setState((prevState, currentProps) => ({
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             foo: !this.state.foo,
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                  ~~~~~~~~~~~~~~ [0]
             bar: currentProps.bar
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         }));
-~~~~~~~~~~~ [0]
 
         this.setState((prevState, currentProps) => {
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             this.fooBar(this.state.foo);
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        ~~~~~~~~~~~~~~ [0]
             return {
-~~~~~~~~~~~~~~~~~~~~
                 bar: !prevState.bar
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             };
-~~~~~~~~~~~~~~
         });
-~~~~~~~~~~ [0]
     }
 }
 
-[0]: Use callback in setState when referencing the previous state.
+[0]: Avoid using this.state in first argument of setState.

--- a/test/rules/no-access-state-in-setstate/test.tsx.lint
+++ b/test/rules/no-access-state-in-setstate/test.tsx.lint
@@ -47,13 +47,13 @@ class SomeReactComponent extends React.Component {
 
         this.setState((prevState, currentProps) => ({
             foo: !this.state.foo,
-                  ~~~~~~~~~~~~~~ [0]
+                  ~~~~~~~~~~~~~~ [1]
             bar: currentProps.bar
         }));
 
         this.setState((prevState, currentProps) => {
             this.fooBar(this.state.foo);
-                        ~~~~~~~~~~~~~~ [0]
+                        ~~~~~~~~~~~~~~ [1]
             return {
                 bar: !prevState.bar
             };
@@ -61,4 +61,5 @@ class SomeReactComponent extends React.Component {
     }
 }
 
-[0]: Avoid using this.state in first argument of setState.
+[0]: References to this.state are not allowed in the setState state change object.
+[1]: References to this.state are not allowed in the setState updater, use the callback arguments instead.

--- a/test/rules/no-access-state-in-setstate/test.tsx.lint
+++ b/test/rules/no-access-state-in-setstate/test.tsx.lint
@@ -28,6 +28,14 @@ class SomeReactComponent extends React.Component {
         }));
 
         this.setState({
+            foo: window.history.length
+        });
+
+        this.setState({
+            foo: !this.props.bar
+        });
+
+        this.setState({
             foo: !this.state.foo
                   ~~~~~~~~~~~~~~ [0]
         });

--- a/test/rules/no-access-state-in-setstate/test.tsx.lint
+++ b/test/rules/no-access-state-in-setstate/test.tsx.lint
@@ -1,0 +1,68 @@
+class SomeReactComponent extends React.Component {
+
+    someClassFunction() {
+
+        this.fooBar({
+            foo: this.state.foo
+        });
+
+        this.setState({
+            foo: "foo",
+            bar: this.barz
+        });
+
+        this.setState(
+            {
+                foo: "foo"
+            },
+            () => this.fooBar(this.state.foo);
+        );
+
+        this.setState(prevState => ({
+            foo: !prevState.foo
+        }));
+
+        this.setState((prevState, currentProps) => ({
+            foo: !prevState.foo,
+            bar: currentProps.bar
+        }));
+
+        this.setState({
+        ~~~~~~~~~~~~~~~
+            foo: !this.state.foo
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        });
+~~~~~~~~~~ [0]
+
+        this.setState({
+        ~~~~~~~~~~~~~~~
+            foo: this.fooBar(this.state.foo)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        });
+~~~~~~~~~~ [0]
+
+        this.setState((prevState, currentProps) => ({
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            foo: !this.state.foo,
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            bar: currentProps.bar
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        }));
+~~~~~~~~~~~ [0]
+
+        this.setState((prevState, currentProps) => {
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            this.fooBar(this.state.foo);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            return {
+~~~~~~~~~~~~~~~~~~~~
+                bar: !prevState.bar
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            };
+~~~~~~~~~~~~~~
+        });
+~~~~~~~~~~ [0]
+    }
+}
+
+[0]: Use callback in setState when referencing the previous state.

--- a/test/rules/no-access-state-in-setstate/tslint.json
+++ b/test/rules/no-access-state-in-setstate/tslint.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "no-access-state-in-setstate": true
+    }
+}


### PR DESCRIPTION
Fixes #172 (and #80 to some extent)

#### Overview of change:

Took ESLint-plugin-React's no-access-state-in-setstate rule and implemented it in tslint-react. I know no maintainer seems to have reviewed #172 yet, but I took a swing at it anyway, hope that was okay! 

#### Is there anything you'd like reviewers to focus on?

You will find that I did the checks with pretty simple string comparisons (e.g. `expression.getText().indexOf("this.state.") !== -1;`). I started creating the checks with actually using the AST but found that the string solution is not only imho more reliable but of course also a lot easier to write and understand. But maybe there're better ways to check it!

No matter the way the check of the ``this.setState`` argument is implemented, there are still ways to bypass the check and creating - if you want so - false-positives.
```ts
class MyReactComponent extend React.Component {
  // ...
  
  myFunction() {
    this.setState({
      foo: this.state.foo + 1 // Rule will detect this
    });

    const foo = this.state.foo;
    this.setState({
      foo: foo + 1 // Still using this.state, rule won't mark it
    });
    
    this.setState({
      foo: getFoo() // Also this.state, won't be detected
    })
  }

  getFoo() {
    return this.state.foo;
  }
}
```
You'd have to determine every variable containing (or deriving from) the current state and every functions whose return value depends on it, and then check if those variables and methods are used in `this.setState`. ESLint-plugin-React even does something like that.
But I guess my pull request atleast offers a good starting point and will catch most of the error-prone code lines.
Since English isn't my first language, all texts (e.g. rule description) might be improvable :-)
Looking forward to your review!
