### PR TITLE
Fix jsx-wrap-multiline rule for closing parenthesis

### DIFF
--- a/src/rules/jsxWrapMultilineRule.ts
+++ b/src/rules/jsxWrapMultilineRule.ts
@@ -78,16 +78,11 @@ class JsxWrapMultilineWalker extends Lint.AbstractWalker<void> {
 
         const scanner = this.getScanner(sourceFile);
         scanner.setTextPos(node.getFullStart() - 1);
-        const prevTokenKind = scanner.scan();
         const siblings = node.parent.getChildren(sourceFile);
-        const index = siblings.indexOf(node);
+        const index = siblings.findIndex((n) => n.pos === node.pos && n.end === node.end);
 
         const previousToken = siblings[index - 1];
         const nextToken = siblings[index + 1];
-
-        if (prevTokenKind === ts.SyntaxKind.OpenParenToken && node.getFullText().match(/^[\r\n]+/) !== null) {
-            return;
-        }
 
         if (nextToken == null || nextToken.kind !== ts.SyntaxKind.CloseParenToken) {
             this.addFailureAtNode(node, Rule.FAILURE_NOT_WRAPPED);

--- a/test/rules/jsx-wrap-multiline/test.tsx.lint
+++ b/test/rules/jsx-wrap-multiline/test.tsx.lint
@@ -47,6 +47,22 @@ const badWrappedWithoutNewLines = (<div
 </div>);
       ~   [New line required before close parenthesis when wrapping multiline JSX elements]
 
+const badWrappedWithoutNewLineAtOpen = (<div
+                                       ~      [New line required after open parenthesis when wrapping multiline JSX elements]
+    className="my-class"
+>
+    {children}
+</div>
+);
+
+const badWrappedWithoutNewLineAtClose = (
+    <div
+        className="my-class"
+    >
+        {children}
+    </div>);
+          ~   [New line required before close parenthesis when wrapping multiline JSX elements]
+
 const goodSingleLineWrappedWithoutNewLines = (<div className="my-class">{children}</div>);
 
 const goodNestedElements = (


### PR DESCRIPTION
There was a bug in this rule: having the opening parenthesis on a new line before the opening tag, but the closing parenthesis on the same line as the closing tag, would not trigger this rule.
This was caused by the fact that the `index` variable (as calculated by `siblings.indexOf`) was equal to -1 in some cases.
The `index` is now calculated by checking just the `pos` and `end` fields of a `node`, instead of the default object equality that `indexOf` uses.

With this change, the check that tested whether the node started with a newline is no longer needed (and with it, also the `prevTokenKind` variable is no longer needed).

Also, two tests have been added:

- A multiline JSX component with the closing parenthesis on a new line, but the opening parenthisis on the same line
- A multiline JSX component with the opening parenthesis on a new line, but the closing parenthisis on the same line