### PR TITLE
Add rule for React Hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ The built-in configuration preset you get with `"extends": "tslint-react"` is se
       </button>
   );
   ```
+- `react-hooks-nesting` (since v3.7)
+  - Enforces correct use of React Hooks.
+  - Prevents using hooks conditionally
+  - Prevents using hooks in functions that are not components or custom hooks
+  - More information: [tslint-react-hooks](https://github.com/Gelio/tslint-react-hooks)
+  - Similar to [eslint-plugin-react-hooks](https://github.com/facebook/react/tree/master/packages/eslint-plugin-react-hooks)
+  
 
 ### Development
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "verify": "run-s build lint test"
   },
   "dependencies": {
+    "tslint-react-hooks": "^1.1.0",
     "tsutils": "^2.13.1"
   },
   "peerDependencies": {

--- a/tslint-react.json
+++ b/tslint-react.json
@@ -1,4 +1,5 @@
 {
+    "extends": ["tslint-react-hooks"],
     "rulesDirectory": "./rules",
     "rules": {
         "jsx-alignment": true,
@@ -11,6 +12,7 @@
         "jsx-no-multiline-js": true,
         "jsx-no-string-ref": true,
         "jsx-self-close": true,
-        "jsx-wrap-multiline": true
+        "jsx-wrap-multiline": true,
+        "react-hooks-nesting": true
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -464,6 +464,11 @@ tslint-language-service@^0.9.6:
   version "0.9.6"
   resolved "https://registry.yarnpkg.com/tslint-language-service/-/tslint-language-service-0.9.6.tgz#882bb0704cf8397b332ddc0af7168c7f22f279ea"
 
+tslint-react-hooks@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tslint-react-hooks/-/tslint-react-hooks-1.1.0.tgz#f1b96ec5177790ce9298e8d2d767b68de1f42c73"
+  integrity sha512-x6I2KShGpW9spMIGLrXeLiGXXr4g5mrXMRgjpDgO//73ZosyYKQ0aLqnJDDM+KAHM8fDPd3WtnWOF3U2Yk8wIA==
+
 tslint@^5.5.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.6.0.tgz#088aa6c6026623338650b2900828ab3edf59f6cf"


### PR DESCRIPTION
I created [a rule for detecting improper uses of React Hooks](https://github.com/Gelio/tslint-react-hooks). For more information about the rule take a look at the [tslint-react-hooks](https://github.com/Gelio/tslint-react-hooks) repository.

This PR integrates the `react-hooks-nesting` into this repository.

I built `tslint-react` with the newly added rule and it works correctly with both `react-hooks-nesting` and built in this repository (example that reports both `react-hooks-nesting` for using a hook inside `if` and `jsx-wrap-multiline`):

![image](https://user-images.githubusercontent.com/889383/52694029-bc135a80-2f68-11e9-9110-396a9c893904.png)

`tslint.json` contained only the following:

```json
{
  "extends": "tslint-react"
}
```

This PR is related to #186.