### PR TITLE
fix: add option for custom-attributes in rule jsx-use-translation-function

### DIFF
--- a/test/rules/jsx-use-translation-function/allow-customattributes/test.tsx.lint
+++ b/test/rules/jsx-use-translation-function/allow-customattributes/test.tsx.lint
@@ -1,0 +1,17 @@
+<CustomComponent
+    customProp1={translate("Name")}
+    customProp2={translate("Name2")}
+    customProp3={translate("Name3")}
+/>
+
+<CustomComponent
+    customProp1="Name1"
+                ~~~~~~~ [0 % ('customProp1')]
+    customProp2="Name2"
+                ~~~~~~~ [0 % ('customProp2')]
+    customProp3="Name3"
+                ~~~~~~~ [0 % ('customProp3')]
+    customProp4="Name4"
+/>
+
+[0]: String literal is not allowed for value of %s. Use a translation function

--- a/test/rules/jsx-use-translation-function/allow-customattributes/tslint.json
+++ b/test/rules/jsx-use-translation-function/allow-customattributes/tslint.json
@@ -1,0 +1,9 @@
+{
+    "rules": {
+        "jsx-use-translation-function": {
+            "options": [{
+                "allow-customattributes": ["customProp1", "customProp2", "customProp3"]
+            }]
+        }
+    }
+}


### PR DESCRIPTION
#### PR checklist
- [x] Addresses an existing issue: fixes #98
- [x]  bugfix
- [x] Includes tests
- [x]  Documentation update

#### Overview of change:
Added an option `allow-customattributes` which accepts an array of custom attributes to check if translation function is used.

```
{
    "rules": {
        "jsx-use-translation-function": {
            "options": [{
                "allow-customattributes": ["customProp1", "customProp2", "customProp3"]
            }]
        }
    }
}

```