### PR TITLE
207-Allow mutiline comment in jsx-no-multiline

### DIFF
--- a/src/rules/jsxNoMultilineJsRule.ts
+++ b/src/rules/jsxNoMultilineJsRule.ts
@@ -42,11 +42,17 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 function walk(ctx: Lint.WalkContext<void>): void {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
-        if (isJsxExpression(node)) {
+        if (isJsxExpression(node) && !isCommentBlock(node)) {
             if (node.getText().indexOf("\n") > -1) {
                 ctx.addFailureAt(node.getStart(), node.getWidth(), Rule.FAILURE_STRING);
             }
         }
         return ts.forEachChild(node, cb);
     });
+}
+
+function isCommentBlock(node: ts.JsxExpression) {
+    const text = node.getText().trim();
+
+    return text.startsWith("{/*") && text.endsWith("*/}");
 }

--- a/test/rules/jsx-no-multiline-js/test.tsx.lint
+++ b/test/rules/jsx-no-multiline-js/test.tsx.lint
@@ -62,3 +62,35 @@ const ele = <button className={{
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 }} />;
 ~~ [Multiline JS expressions inside JSX are forbidden]
+
+
+const ele = <div>
+    <div>Some Text</div>
+    {/* <div>
+        Some commented code...
+    </div> */}
+</div>;
+
+
+const ele = <div>
+    {/*
+        
+    
+    <div>
+        Some commented code...
+    </div>
+    
+    */}
+    <div>Some Text</div>
+    {/* <div>
+        Some commented code...
+    </div> */}
+    {/* <div>
+        Some commented code...
+    </div> */}
+</div>; 
+
+const ele = <div>
+    <div>Some Text</div>
+    {/*  */}
+</div>;


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #207  
- [x] enhancement
- [x] Includes tests
- [ ] Documentation update

#### Overview of change:
check if `JSXExpression` starts with `{/*` and ends with `*/}`