### PR TITLE
fix jsx-no-bind to address any function binding (not just methods)

### DIFF
--- a/src/rules/jsxNoBindRule.ts
+++ b/src/rules/jsxNoBindRule.ts
@@ -64,7 +64,7 @@ function walk(ctx: Lint.WalkContext<void>): void {
         const { expression } = initializer;
         if (expression === undefined
             || !isCallExpression(expression)
-            || !expression.getText(ctx.sourceFile).includes(".bind(this)")) {
+            || !expression.getText(ctx.sourceFile).includes(".bind(")) {
             return;
         }
 


### PR DESCRIPTION
I've encountered a code that contains function binding of the form: `< ... onConfirm={execute.bind(null, someProp)} >` 
IMO jsx-no-bind should alert on this